### PR TITLE
Remove the node.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "type": "git",
     "url": "git://github.com/netpro2k/hubot-skype.git"
   },
-  "dependencies": {
-    "hubot": ">=2.3.4"
-  },
   "devDependencies": {
     "coffee-script": ">=1.1.3"
   },


### PR DESCRIPTION
I noticed that hubot wasn't sending any messages to Skype, but it was receiving them just fine. After some digging I found this: https://github.com/nandub/hubot-irc/issues/4

After removing the dependency everything worked smoothly. I was using the downloaded 2.3.2 version.
