### PR TITLE
Environment variable for custom location of the python executable

### DIFF
--- a/src/skype.coffee
+++ b/src/skype.coffee
@@ -17,7 +17,7 @@ class SkypeAdapter extends Adapter
     stdin = process.openStdin()
     stdout = process.stdout
     pyScriptPath = __dirname+'/skype.py'
-    py = process.env.HUBOT_SKYPE_ADAPTER_PYTHON
+    py = process.env.HUBOT_SKYPE_PYTHON
     
     if (!py)
         if (process.platform == 'win32')

--- a/src/skype.coffee
+++ b/src/skype.coffee
@@ -17,10 +17,14 @@ class SkypeAdapter extends Adapter
     stdin = process.openStdin()
     stdout = process.stdout
     pyScriptPath = __dirname+'/skype.py'
-    if (process.platform == 'win32')
-        py = 'C:/Python27/python.exe'
-    else
-        py = 'python'
+    py = process.env.HUBOT_SKYPE_ADAPTER_PYTHON
+    
+    if (!py)
+        if (process.platform == 'win32')
+            py = 'C:/Python27/python.exe'
+        else
+            py = 'python'
+
     @skype = require('child_process').spawn(py, [pyScriptPath])
     @skype.stdout.on 'data', (data) =>
         decoded = JSON.parse(data.toString())


### PR DESCRIPTION
My python isn't installed in c:\python27. So i added an environment variable named HUBOT_SKYPE_PYTHON.

Usage: 

```
set HUBOT_SKYPE_PYTHON=D:\Tools\Python27\python.exe
node .\node_modules\coffee-script\bin\coffee .\bin\hubot -a skype
```
