### PR TITLE
Kill the python process on exit

### DIFF
--- a/src/skype.coffee
+++ b/src/skype.coffee
@@ -47,6 +47,9 @@ class SkypeAdapter extends Adapter
     process.on "uncaughtException", (err) =>
       @robot.logger.error "#{err}"
 
+    process.on "exit", =>
+          @skype.kill()
+
     @emit "connected"
 
 exports.use = (robot) ->


### PR DESCRIPTION
I found that the python child process wasn't killed along with hubot. There may be a better solution, but this seems to fix it for me.
